### PR TITLE
Fix `rspec-rails` gem issues (#626)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem 'faker', '~> 3.2'
   gem 'pry-byebug', '~> 3.9', platform: :mri
   gem 'pry-rails', '~> 0.3.9'
+  gem 'rspec-rails', '~> 6.1'
 end
 
 group :development do
@@ -79,7 +80,6 @@ group :test do
   gem 'pg_query', '~> 5.1.0'
   gem 'prosopite', '~> 1.4.2'
   gem 'rspec-openapi', '~> 0.12'
-  gem 'rspec-rails', '~> 6.1'
   gem 'rspec-retry', github: 'rootstrap/rspec-retry', branch: 'add-intermittent-callback'
   gem 'selenium-webdriver', '~> 4.17.0'
   gem 'shoulda-matchers', '~> 6.1'


### PR DESCRIPTION
* Remove spring gem

Spring does not support Rails 7.1 and Ruby 3.3,
which are both used in this project.

* Add arctic_admin gem

If you attempt to run a fresh installation of this repo, the tests won't pass because of the importations:
- As the arctic_admin gem is not initially on the gemfile, it will cause the system specs to fail.
- We also need to have the `active_admin.js` in order to pass the specs (and ensure functionality).

Worth mentioning that `arctic_admin/base` already adds `mixins` and `fontawesome`, so there might be no need to add them manually.

* Remove arctic_admin gem and move rspec-rails gem

rspec-rails gem should be in dev and test environment

* Add spring back

* Update Gemfile

---------

#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
<!-- * Add a description of what is the aim of this PR -->
---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
